### PR TITLE
Fix: Wrong bats URL and duplicate test error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ test/%: deps/bats test/fixtures/dot-test/ellipsis.sh
 
 deps/bats:
 	@mkdir -p deps
-	git clone --depth 1 git://github.com/sstephenson/bats.git deps/bats
+	git clone --depth 1 https://github.com/sstephenson/bats.git deps/bats
 
 test/fixtures/dot-test/ellipsis.sh:
 	git submodule init

--- a/test/init.bats
+++ b/test/init.bats
@@ -11,6 +11,3 @@ load init
     skip "No test implementation"
 }
 
-@test "load should source extension specific files if possible" {
-    skip "No test implementation"
-}


### PR DESCRIPTION
# Description

Fix a duplicate code issue that makes tests to fail. Also, I updated the bats git URL as it does not seems to work with this format.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

The tests now run without errors.